### PR TITLE
add tag method to take LRG_USER and LRG_TAGS from os.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ For training and inference performance results on Intel Gaudi2 accelerators, see
 
 > **Note**
 > Make sure to go through the installation steps above before trying the quickstart!
+> You can set env variables `LRG_USER` and `LRG_TAGS` to tag your runs or add them
+> to `loggers.aim.tags` in yml config.
 
 Here is an end-to-end workflow for preparing a subset of the C4 dataset, training an MPT-125M model for 10 batches,
 converting the model to HuggingFace format, evaluating the model on the Winograd challenge, and generating responses to prompts.

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -113,7 +113,7 @@ class AimLogger(LoggerDestination):
 
     def _add_env_var_tags(self):
         user = os.environ.get('LRG_USER')
-        if user: self._run.add_tag(user)
+        if user: self._run.add_tag(f"U-{user}")
         tags = os.environ.get('LRG_TAGS')
         if tags: [self._run.add_tag(t) for t in tags.split(',') if t]
     
@@ -127,7 +127,9 @@ class AimLogger(LoggerDestination):
             main_type = gpu_types[0].strip()
             count = len([t for t in gpu_types if t.strip() == main_type])
             self._run.add_tag(f"GPU-{main_type}x{count}")
-        except: pass
+        except Exception as e:
+            print(f"Failed to add GPU tag: {e}")
+            sys_logger.warning(f"Failed to add GPU tag: {e}")
 
     def _setup(self, state: Optional[State] = None):
         """Initialize the Aim Run if not already initialized."""

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -241,6 +241,7 @@ class AimLogger(LoggerDestination):
         # In WandB: wandb.config.update(hyperparameters)
         # In Aim, we just store them in a nested dictionary key, or flatten them:
         self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
+        self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 
         sys_logger.info(f"Finished logging hyperparameters.")
         print(f"Finished logging hyperparameters.")
 

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -251,10 +251,10 @@ class AimLogger(LoggerDestination):
         for k, v in hyperparameters.items():
             self._run.set(('hparams', k), v)
             self._run.set(('hparams', k, str(uuid4()).replace('-', '')), v) # Testing if there are overwrites
-            if isinstance(v, dict):
-                for k2, v2 in v.items():
-                    self._run.set(('hparams', k, 'l2', k2), v2)
-                    self._run.set(('hparams', k, 'l2', k2, str(uuid4()).replace('-', '')), v2) # Testing if there are overwrites
+            # if isinstance(v, dict):
+            #     for k2, v2 in v.items():
+            #         self._run.set(('hparams', k, 'l2', k2), v2)
+            #         self._run.set(('hparams', k, 'l2', k2, str(uuid4()).replace('-', '')), v2) # Testing if there are overwrites
 
         # self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
         # self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -122,7 +122,7 @@ class AimLogger(LoggerDestination):
         try:
             import re, subprocess
             gpu_info = subprocess.check_output('nvidia-smi -L', shell=True).decode()
-            gpu_types = re.findall(r':\s*(?:NVIDIA\s+)?(?:GeForce\s+)?(?:RTX|GTX\s+)?([A-Z0-9 -_]+)\s*\(', gpu_info)
+            gpu_types = re.findall(r':\s*(?:NVIDIA\s+)?(?:GeForce\s+)?(?:RTX|GTX\s+)?([A-Z0-9 \-_]+)\s*\(', gpu_info)
             if not gpu_types: return
             main_type = gpu_types[0].strip()
             count = len([t for t in gpu_types if t.strip() == main_type])
@@ -175,6 +175,7 @@ class AimLogger(LoggerDestination):
                 self._log_hparams(state)
             
             self._add_env_var_tags()
+            self._add_gpu_tag()
             if self.tags:
                 if isinstance(self.tags, str): self._run.add_tag(self.tags)
                 else: [self._run.add_tag(t) for t in list(self.tags)]

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -129,8 +129,8 @@ class AimLogger(LoggerDestination):
             main_type = gpu_types[0].strip()
             count = len([t for t in gpu_types if t.strip() == main_type])
             self._run.add_tag(f"GPU-{main_type}x{count}")
-            self._run.set('GPU', main_type)
-            self._run.set('GPU-COUNT', count)
+            self._run.set('gpu', main_type)
+            self._run.set('gpu_count', count)
         except Exception as e:
             print(f"Failed to add GPU tag: {e}")
             sys_logger.warning(f"Failed to add GPU tag: {e}")
@@ -201,15 +201,13 @@ class AimLogger(LoggerDestination):
             if state.model: default_hparams['model_class'] = state.model.__class__.__name__
             for k, v in default_hparams.items():
                 self._run.set(('state', k), v)
-                self._run.set(('state', f"{k}_{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites
+                # self._run.set(('state', f"{k}_{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites (there were not in the initial testing)
             state_dict = state.state_dict()
             if state_dict:
                 for k, v in state_dict.items():
                     self._run.set(('state', k), v)
-                    self._run.set(('state', f"{k}__{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites
+                    # self._run.set(('state', f"{k}__{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites (there were not in the initial testing)
 
-            # If you want to log your entire config dictionary, you can do so:
-            # self._run['composer/config'] = state.get_serialized_attributes()  # Example only
             # If you want to log your entire config dictionary, you can do so:
             # self._run['composer/config'] = state.get_serialized_attributes()  # Example only
             # Or if the user's separate hyperparameter dictionary is known, do:
@@ -250,16 +248,8 @@ class AimLogger(LoggerDestination):
         # In Aim, we just store them in a nested dictionary key, or flatten them:
         for k, v in hyperparameters.items():
             self._run.set(('hparams', k), v)
-            self._run.set(('hparams', f"{k}___{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites
-            # if isinstance(v, dict):
-            #     for k2, v2 in v.items():
-            #         self._run.set(('hparams', k, 'l2', k2), v2)
-            #         self._run.set(('hparams', k, 'l2', k2, str(uuid4()).replace('-', '')), v2) # Testing if there are overwrites
+            # self._run.set(('hparams', f"{k}___{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites (there were not in the initial testing)
 
-        # self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
-        # self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})
-        # self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 
-        # self._run['hparams4'] = str({k: v for k, v in hyperparameters.items()})
         sys_logger.info(f"Finished logging hyperparameters.")
         print(f"Finished logging hyperparameters.")
 

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -210,6 +210,15 @@ class AimLogger(LoggerDestination):
 
     def log_hyperparameters(self, hyperparameters: dict[str, Any]):
         """Log arbitrary hyperparameters to Aim."""
+        if "model" in hyperparameters:
+            model = hyperparameters.get("model", None)
+            if model:
+                mn = model.get("name")
+                self._run.add_tag(f"model-{mn}")
+        if "global_train_batch_size" in hyperparameters:
+            mtbs = hyperparameters.get("global_train_batch_size", None)
+            if mtbs:
+                self._run.add_tag(f"batch-size-{mtbs}")
         if not self._enabled or not self._run:
             return
         # In WandB: wandb.config.update(hyperparameters)

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -253,9 +253,9 @@ class AimLogger(LoggerDestination):
             self._run.set(('hparams', k, str(uuid4()).replace('-', '')), v) # Testing if there are overwrites
             if isinstance(v, dict):
                 for k2, v2 in v.items():
-                    self._run.set(('hparams', k, k2), v2)
-                    self._run.set(('hparams', k, k2, str(uuid4()).replace('-', '')), v2) # Testing if there are overwrites
-        
+                    self._run.set(('hparams', k, 'l2', k2), v2)
+                    self._run.set(('hparams', k, 'l2', k2, str(uuid4()).replace('-', '')), v2) # Testing if there are overwrites
+
         # self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
         # self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})
         # self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -99,7 +99,7 @@ class AimLogger(LoggerDestination):
         atexit.register(self._set_is_in_atexit)
         self.upload_on_close = upload_on_close
         self.tags = tags
-        hparams_to_tags = dict(hparams_to_tags) if hparams_to_tags is not None else {}
+        self.hparams_to_tags = dict(hparams_to_tags) if hparams_to_tags is not None else {}
 
     def _set_is_in_atexit(self):
         self._is_in_atexit = True

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -201,12 +201,12 @@ class AimLogger(LoggerDestination):
             if state.model: default_hparams['model_class'] = state.model.__class__.__name__
             for k, v in default_hparams.items():
                 self._run.set(('state', k), v)
-                self._run.set(('state', k, str(uuid4()).replace('-', '')), v) # Testing if there are overwrites
+                self._run.set(('state', f"{k}_{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites
             state_dict = state.state_dict()
             if state_dict:
                 for k, v in state_dict.items():
                     self._run.set(('state', k), v)
-                    self._run.set(('state', k, str(uuid4()).replace('-', '')), v) # Testing if there are overwrites
+                    self._run.set(('state', f"{k}__{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites
 
             # If you want to log your entire config dictionary, you can do so:
             # self._run['composer/config'] = state.get_serialized_attributes()  # Example only
@@ -250,7 +250,7 @@ class AimLogger(LoggerDestination):
         # In Aim, we just store them in a nested dictionary key, or flatten them:
         for k, v in hyperparameters.items():
             self._run.set(('hparams', k), v)
-            self._run.set(('hparams', k, str(uuid4()).replace('-', '')), v) # Testing if there are overwrites
+            self._run.set(('hparams', f"{k}___{str(uuid4()).replace('-', '')}"), v) # Testing if there are overwrites
             # if isinstance(v, dict):
             #     for k2, v2 in v.items():
             #         self._run.set(('hparams', k, 'l2', k2), v2)

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -195,10 +195,13 @@ class AimLogger(LoggerDestination):
                 'optimizer': state.optimizers[0].__class__.__name__ if state.optimizers and len(state.optimizers) > 0 else None,
             }
             if state.model: default_hparams['model_class'] = state.model.__class__.__name__
-            default_hparams['state'].update(dict(state.get_model_state_dict()))
-
             self._run['state'] = default_hparams
+            state_dict = state.get_model_state_dict()
+            if state_dict:
+                default_hparams['state'].update(dict(state_dict))
 
+            # If you want to log your entire config dictionary, you can do so:
+            # self._run['composer/config'] = state.get_serialized_attributes()  # Example only
             # If you want to log your entire config dictionary, you can do so:
             # self._run['composer/config'] = state.get_serialized_attributes()  # Example only
             # Or if the user's separate hyperparameter dictionary is known, do:
@@ -224,6 +227,8 @@ class AimLogger(LoggerDestination):
 
     def log_hyperparameters(self, hyperparameters: dict[str, Any]):
         """Log arbitrary hyperparameters to Aim."""
+        sys_logger.info(f"Logging hyperparameters: {hyperparameters}")
+        print(f"Logging hyperparameters: {hyperparameters}")
         for hparam_to_tag, tag_prefix in self.hparams_to_tags.items():
             hparam_value = self._get_nested(hyperparameters, hparam_to_tag)
             if hparam_value is not None:
@@ -236,6 +241,8 @@ class AimLogger(LoggerDestination):
         # In WandB: wandb.config.update(hyperparameters)
         # In Aim, we just store them in a nested dictionary key, or flatten them:
         self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
+        sys_logger.info(f"Finished logging hyperparameters.")
+        print(f"Finished logging hyperparameters.")
 
     def log_table(
         self,

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -240,7 +240,9 @@ class AimLogger(LoggerDestination):
             return
         # In WandB: wandb.config.update(hyperparameters)
         # In Aim, we just store them in a nested dictionary key, or flatten them:
+
         self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
+        self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})
         self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 
         sys_logger.info(f"Finished logging hyperparameters.")
         print(f"Finished logging hyperparameters.")

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -233,6 +233,11 @@ class AimLogger(LoggerDestination):
 
     def log_hyperparameters(self, hyperparameters: dict[str, Any]):
         """Log arbitrary hyperparameters to Aim."""
+        if not self._enabled or not self._run:
+            sys_logger.info(f"Aim logger not enabled or not initialized. Skipping hyperparameter logging.")
+            print(f"Aim logger not enabled or not initialized. Skipping hyperparameter logging.")
+            return
+        
         sys_logger.info(f"Logging hyperparameters: {hyperparameters}")
         print(f"Logging hyperparameters: {hyperparameters}")
         for hparam_to_tag, tag_prefix in self.hparams_to_tags.items():
@@ -241,9 +246,6 @@ class AimLogger(LoggerDestination):
                 if (isinstance(hparam_value, str) and '/' in hparam_value and len(hparam_value.split('/')[-1]) > 1): 
                     hparam_value = hparam_value.split('/')[-1]
                 self._run.add_tag(f"{tag_prefix}-{hparam_value}")
-
-        if not self._enabled or not self._run:
-            return
         # In WandB: wandb.config.update(hyperparameters)
         # In Aim, we just store them in a nested dictionary key, or flatten them:
         for k, v in hyperparameters.items():

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -195,10 +195,12 @@ class AimLogger(LoggerDestination):
                 'optimizer': state.optimizers[0].__class__.__name__ if state.optimizers and len(state.optimizers) > 0 else None,
             }
             if state.model: default_hparams['model_class'] = state.model.__class__.__name__
-            self._run['state'] = default_hparams
+            for k, v in default_hparams.items():
+                self._run.set(('state', k), v)
             state_dict = state.state_dict()
             if state_dict:
-                default_hparams['state'].update(dict(state_dict))
+                for k, v in state_dict.items():
+                    self._run.set(('state', k), v)
 
             # If you want to log your entire config dictionary, you can do so:
             # self._run['composer/config'] = state.get_serialized_attributes()  # Example only
@@ -240,11 +242,12 @@ class AimLogger(LoggerDestination):
             return
         # In WandB: wandb.config.update(hyperparameters)
         # In Aim, we just store them in a nested dictionary key, or flatten them:
-
-        self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
-        self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})
-        self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 
-        self._run['hparams4'] = str({k: v for k, v in hyperparameters.items()})
+        for k, v in hyperparameters.items():
+            self._run.set(('hparams', k), v)
+        # self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
+        # self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})
+        # self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 
+        # self._run['hparams4'] = str({k: v for k, v in hyperparameters.items()})
         sys_logger.info(f"Finished logging hyperparameters.")
         print(f"Finished logging hyperparameters.")
 

--- a/llmfoundry/loggers/composer_aim_logger.py
+++ b/llmfoundry/loggers/composer_aim_logger.py
@@ -196,7 +196,7 @@ class AimLogger(LoggerDestination):
             }
             if state.model: default_hparams['model_class'] = state.model.__class__.__name__
             self._run['state'] = default_hparams
-            state_dict = state.get_model_state_dict()
+            state_dict = state.state_dict()
             if state_dict:
                 default_hparams['state'].update(dict(state_dict))
 
@@ -244,6 +244,7 @@ class AimLogger(LoggerDestination):
         self._run['hparams'] = {k: v for k, v in hyperparameters.items()}
         self._run['hparams3'] = str({k: v for k, v in hyperparameters.items()})
         self._run['hparams2'] = {'test1': 'test2', 'test3': 'test4'} 
+        self._run['hparams4'] = str({k: v for k, v in hyperparameters.items()})
         sys_logger.info(f"Finished logging hyperparameters.")
         print(f"Finished logging hyperparameters.")
 

--- a/scripts/modal/modal_script.py
+++ b/scripts/modal/modal_script.py
@@ -41,10 +41,11 @@ def get_stats():
 
     # Run nvidia-smi to check GPU status
     nvidia_smi = subprocess.run(['nvidia-smi'], capture_output=True, text=True)
+    nvidia_smi_2 = subprocess.run(['nvidia-smi', '-L'], capture_output=True, text=True)
     print("NVIDIA-SMI Output:")
     print(nvidia_smi.stdout)
-    if nvidia_smi.stderr:
-        print("NVIDIA-SMI Errors:", nvidia_smi.stderr)
+    print(nvidia_smi_2.stdout)
+    if nvidia_smi.stderr: print("NVIDIA-SMI Errors:", nvidia_smi.stderr)
 
 
 @app.function(gpu=TRAINING_GPU, image=image, timeout=3600, secrets=[Secret.from_name("LRG")], 

--- a/scripts/modal/modal_script.py
+++ b/scripts/modal/modal_script.py
@@ -11,8 +11,8 @@ PYTHON_PATH = "/opt/conda/envs/llm-foundry/bin/python"
 TRAINING_GPU = "h100" # "a10g" "h100" # "l4"
 BATCH_SIZE = 20 # 20 for h100 4 for l4
 TRAIN_DURATION="100ba"
-EVAL_DURATION="100ba"
-SAVE_INTERVAL="50ba"    
+EVAL_INTERVAL="100ba"
+SAVE_INTERVAL="100ba"    
 
 DATASET_BASE_PATH = "/datasets"
 DATASETS_VOLUME = Volume.from_name("lrg-datasets", create_if_missing=True)

--- a/scripts/modal/modal_script.py
+++ b/scripts/modal/modal_script.py
@@ -24,7 +24,7 @@ MODEL_CHECKPOINT_VOLUME_MOUNT_PATH = pathlib.Path("/model-checkpoints")
 app = App("quick-start")
 
 # Build image from local Dockerfile
-image = Image.from_dockerfile("Dockerfile")
+image = Image.from_dockerfile("Dockerfile", gpu='l4')
 
 @app.function(gpu=TRAINING_GPU, image=image, timeout=3600, secrets=[Secret.from_name("LRG")],
              concurrency_limit=1)
@@ -122,7 +122,7 @@ def train_model(run_ts: str, yaml_path: str = "train/yamls/pretrain/smollm2-135m
 
     save_folder.mkdir(exist_ok=True)
     shutil.copy(yaml_path, Path(save_folder) / Path(yaml_path).name)
-    
+
     train_cmd = [
         "composer",
         "train/train.py",

--- a/scripts/train/yamls/pretrain/smollm2-135m.yaml
+++ b/scripts/train/yamls/pretrain/smollm2-135m.yaml
@@ -29,9 +29,9 @@ loggers:
     repo: '.aim' # Local directory to save the Aim repo
     experiment_name: 'quickstart_test_smollm2_135m' # Group of runs in Aim
     upload_on_close: true # Whether to upload the local Aim repo to the central aim server
-    tags:
-      - 'test1'
-      - 'test2'
+    # tags:
+    #   - 'test1'
+    #   - 'test2'
 
 # Rest of the configuration remains similar to your example, but let's adjust some parameters
 train_loader:

--- a/scripts/train/yamls/pretrain/smollm2-135m.yaml
+++ b/scripts/train/yamls/pretrain/smollm2-135m.yaml
@@ -29,6 +29,9 @@ loggers:
     repo: '.aim' # Local directory to save the Aim repo
     experiment_name: 'quickstart_test_smollm2_135m' # Group of runs in Aim
     upload_on_close: true # Whether to upload the local Aim repo to the central aim server
+    tags:
+      - 'test1'
+      - 'test2'
 
 # Rest of the configuration remains similar to your example, but let's adjust some parameters
 train_loader:


### PR DESCRIPTION
For #33 currently only logs values

* `LRG_USER` from env
* `LRG_TAGS` from env (which can be more than one separated by `,` see image for `LRG_TAGS=env-tag1,env-tag2,env-tag3`)
* model from dict
*  Im using I take `global_train_batch_size` for batch_size from: device_train_batch_size, eval_subset_num_batches, global_train_batch_size, device_eval_batch_size, device_train_microbatch_size (look the dict below)

But not sure were to get this 2 (or we can add them to LRG_TAGS?):

* hyperparameter-sweep
* final-run

Also we have this dict, anything useful from here? (I think there are other dictionaries coming to the method, but w can check them later?)

```
{
  "variables": {
    "data_local": "my-copy-c4",
    "data_remote": null,
    "max_seq_len": 2048,
    "global_seed": 17,
    "run_name": null
  },
  "max_seq_len": 2048,
  "run_name": null,
  "model": {
    "name": "mpt_causal_lm",
    "init_device": "meta",
    "d_model": 768,
    "n_heads": 12,
    "n_layers": 12,
    "expansion_ratio": 4,
    "max_seq_len": 2048,
    "vocab_size": 50368,
    "attn_config": {
      "attn_impl": "torch"
    },
    "loss_fn": "torch_crossentropy"
  },
  "tokenizer": {
    "name": "EleutherAI/gpt-neox-20b",
    "kwargs": {
      "model_max_length": 2048
    }
  },
  "train_loader": {
    "name": "text",
    "dataset": {
      "local": "my-copy-c4",
      "remote": null,
      "split": "train_small",
      "shuffle": true,
      "max_seq_len": 2048,
      "shuffle_seed": 17
    },
    "drop_last": true,
    "num_workers": 0,
    "prefetch_factor": null,
    "persistent_workers": false
  },
  "eval_loader": {
    "name": "text",
    "dataset": {
      "local": "my-copy-c4",
      "remote": null,
      "split": "val_small",
      "shuffle": false,
      "max_seq_len": 2048,
      "shuffle_seed": 17
    },
    "drop_last": false,
    "num_workers": 0,
    "prefetch_factor": null,
    "persistent_workers": false
  },
  "scheduler": {
    "name": "cosine_with_warmup",
    "t_warmup": "100ba",
    "alpha_f": 0.1
  },
  "optimizer": {
    "name": "decoupled_adamw",
    "lr": 0.0006,
    "betas": [
      0.9,
      0.95
    ],
    "eps": 1e-8,
    "weight_decay": 0
  },
  "algorithms": {
    "gradient_clipping": {
      "clipping_type": "norm",
      "clipping_threshold": 1
    }
  },
  "max_duration": "2ba",
  "eval_interval": 0,
  "eval_first": false,



  "eval_subset_num_batches": -1,
  "global_train_batch_size": 32,
  "seed": 17,
  "device_eval_batch_size": 16,
  "device_train_microbatch_size": 8,

  "precision": "FP32",
  "fsdp_config": null,
  "progress_bar": false,
  "log_to_console": true,
  "console_log_interval": "1ba",
  "callbacks": {
    "speed_monitor": {
      "window_size": 10
    },
    "lr_monitor": {},
    "memory_monitor": {},
    "runtime_estimator": {}
  },
  "loggers": {
    "aim": {
      "repo": ".aim",
      "upload_on_close": true
    }
  },
  "save_folder": "output-10",
  "n_gpus": 1,


  "device_train_batch_size": 32,

  "device_train_grad_accum": 4,
  "merge": true,
  "tp_config": null,
  "n_params": 125311488,
  "n_active_params": 125311488,
  "n_trainable_params": 125311488
}
```

<img width="296" alt="image" src="https://github.com/user-attachments/assets/64b4f585-8e90-4d21-b166-f5af3459ec0f" />
