### PR TITLE
Remove extraneous `/llm-foundry` from Line 9 `RUN git clone ...`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 RUN apt-get update && apt-get install -y git nano curl wget && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Clone llm-foundry repo and set up environment
-RUN git clone https://github.com/LocalResearchGroup/llm-foundry.git /llm-foundry && \
+RUN git clone https://github.com/LocalResearchGroup/llm-foundry.git && \
     cd /llm-foundry && \
     micromamba create -n llm-foundry python=3.12 uv cuda -c nvidia/label/12.4.1 -c conda-forge && \
     export UV_PROJECT_ENVIRONMENT=/opt/conda/envs/llm-foundry && \


### PR DESCRIPTION
See #40 for more details. This PR removes an extraneous `/llm-foundry` from the `RUN git clone ...` line 9 in the Dockerfile.