### PR TITLE
Add PEFT adapter format conversion support

### DIFF
--- a/llmfoundry/command_utils/eval.py
+++ b/llmfoundry/command_utils/eval.py
@@ -566,3 +566,141 @@ def eval_from_yaml(
         yaml_cfg = om.merge(yaml_cfg, cli_cfg)
     assert isinstance(yaml_cfg, DictConfig)
     return evaluate(yaml_cfg)
+
+
+def convert_peft_adapter_format(model_dir: str) -> None:
+    """Convert PEFT adapter from safetensors to bin format to avoid device metadata issues.
+    
+    This function performs three operations:
+    1. Converts the adapter weights from safetensors to PyTorch .bin format
+    2. Renames the original safetensors file to .safetensors.bak
+    3. Updates the adapter_config.json to reference .bin files instead of .safetensors
+    
+    Args:
+        model_dir: Full path to the model directory containing PEFT adapter files.
+                  This should be the directory containing:
+                  - adapter_config.json
+                  - adapter_model.safetensors
+                  Example: '/model-checkpoints/llama3-1b-lora-20250420_180800'
+    
+    Returns:
+        None
+    
+    Side Effects:
+        - Creates adapter_model.bin in model_dir
+        - Renames adapter_model.safetensors to adapter_model.safetensors.bak
+        - Modifies adapter_config.json to reference .bin files
+    """
+    import torch
+    import json
+    import os
+    
+    # Paths for the adapter files
+    adapter_path = os.path.join(model_dir, "adapter_model.safetensors")
+    bin_adapter_path = os.path.join(model_dir, "adapter_model.bin")
+    config_path = os.path.join(model_dir, "adapter_config.json")
+    
+    try:
+        # Load and convert if needed
+        if os.path.exists(adapter_path) and not os.path.exists(bin_adapter_path):
+            # Load safetensors adapter with explicit CPU device
+            from safetensors.torch import load_file
+            weights = load_file(adapter_path, device="cpu")
+            
+            # Save as PyTorch bin format
+            torch.save(weights, bin_adapter_path)
+            print(f"Converted adapter to .bin format: {bin_adapter_path}")
+        
+        # Rename/move safetensors file to force bin usage
+        if os.path.exists(adapter_path):
+            backup_path = os.path.join(model_dir, "adapter_model.safetensors.bak")
+            os.rename(adapter_path, backup_path)
+            print(f"Moved safetensors file to {backup_path} to force bin usage")
+        
+        # Update config to reference .bin file
+        if os.path.exists(config_path):
+            with open(config_path, 'r') as f:
+                config = json.load(f)
+            
+            # Update config to use bin file
+            weight_map = config.get("weight_map", {})
+            for key in weight_map:
+                if "safetensors" in weight_map[key]:
+                    weight_map[key] = weight_map[key].replace("safetensors", "bin")
+            
+            # Also update model_type if needed
+            if "safetensors" in config.get("model_type", ""):
+                config["model_type"] = config["model_type"].replace("safetensors", "bin")
+            
+            with open(config_path, 'w') as f:
+                json.dump(config, f, indent=2)
+            
+            print(f"Updated adapter config to use .bin format")
+    except Exception as e:
+        print(f"Failed to convert adapter format: {e}")
+
+
+def restore_safetensors_after_eval(model_dir: str) -> None:
+    """Restore safetensor files to their original state after evaluation.
+    
+    This function reverses the changes made by convert_peft_adapter_format():
+    1. Restores the original adapter_model.safetensors from .bak file if it exists
+    2. Updates the adapter_config.json to reference .safetensors again
+    3. Keeps the .bin file in place for potential future use
+    
+    Args:
+        model_dir: Full path to the model directory containing PEFT adapter files.
+                  This should be the directory containing:
+                  - adapter_config.json
+                  - adapter_model.bin
+                  - adapter_model.safetensors.bak (created by convert_peft_adapter_format)
+                  Example: '/model-checkpoints/llama3-1b-lora-20250420_180800'
+    
+    Returns:
+        None
+    
+    Side Effects:
+        - Restores adapter_model.safetensors from the .bak file if it exists
+        - Modifies adapter_config.json to reference .safetensors files
+        - Keeps adapter_model.bin for potential future use
+    """
+    import os
+    import json
+    
+    # Paths for the adapter files
+    backup_path = os.path.join(model_dir, "adapter_model.safetensors.bak")
+    adapter_path = os.path.join(model_dir, "adapter_model.safetensors")
+    config_path = os.path.join(model_dir, "adapter_config.json")
+    
+    # Only restore if backup exists
+    if os.path.exists(backup_path):
+        if os.path.exists(adapter_path):
+            print(f"Safetensors file already exists at {adapter_path}, skipping restore")
+        else:
+            os.rename(backup_path, adapter_path)
+            print(f"Restored safetensors file from backup")
+            
+        # Update config only if needed
+        if os.path.exists(config_path):
+            with open(config_path, 'r') as f:
+                config = json.load(f)
+            
+            # Check if config needs updating
+            needs_update = False
+            weight_map = config.get("weight_map", {})
+            
+            for key in weight_map:
+                if "bin" in weight_map[key]:
+                    weight_map[key] = weight_map[key].replace("bin", "safetensors")
+                    needs_update = True
+            
+            if "bin" in config.get("model_type", ""):
+                config["model_type"] = config["model_type"].replace("bin", "safetensors")
+                needs_update = True
+            
+            if needs_update:
+                with open(config_path, 'w') as f:
+                    json.dump(config, f, indent=2)
+                print(f"Updated adapter config to use safetensors format")
+    else:
+        print(f"No backup found at {backup_path}, nothing to restore")


### PR DESCRIPTION
# Add PEFT Adapter Support for Model Evaluation

This PR adds utilities for handling PEFT adapters during evaluation to avoid the "device meta is invalid" safetensors error that occurs when evaluating fine-tuned models with adapters.

## Changes

1. Added two utility functions to llmfoundry/command_utils/eval.py
   - convert_peft_adapter_format() : Converts safetensors adapter files to bin format (only if needed). Always updates the adapter_config.json to ensure it references .bin files instead of .safetensors files.
   - restore_safetensors_after_eval(): Restores original files after evaluation (only if backup exists).  Always updates the adapter_config.json to ensure it references .safetensors files instead of .bin files.

## Problem Solved

When evaluating models with PEFT adapters, the evaluation often fails with:
```
safetensors_rust.SafetensorError: device meta is invalid
```

This happens because safetensors files contain device metadata that becomes invalid when loaded in different environments.

## Required Manual Change

**IMPORTANT**: You need to manually rename `scripts/eval/yamls/hf_lora_eval.yml` to `scripts/eval/yamls/hf_lora_eval.yaml` in your environment. This PR does not include this renamed file.

## Testing Note

These functions were tested in the local environment using [local_llama_training_instruct.py](https://github.com/LocalResearchGroup/llm-foundry/blob/llama-modeling-dpv/local_llama_training_instruct.py) but have not yet been tested in the Modal cloud environment. The functions are designed to be environment-agnostic, using only standard Python libraries and conditional logic to handle file operations safely.

## Suggested Integration Guide for Modal Environment

To integrate these changes in your Modal workflow:

```python
@app.function(gpu=TRAINING_GPU, image=image, timeout=3600, secrets=[Secret.from_name("LRG")],
              volumes={MODEL_CHECKPOINT_VOLUME_MOUNT_PATH: MODEL_CHECKPOINT_VOLUME},
              concurrency_limit=1)
def evaluate_model(checkpoint_path: str):
    import subprocess, os
    from pathlib import Path
    
    # Import the adapter conversion utilities
    from llmfoundry.command_utils.eval import convert_peft_adapter_format, restore_safetensors_after_eval
    
    os.chdir("/llm-foundry/scripts")
    print(f"Working directory: {os.getcwd()}")
    
    model_path = Path(MODEL_CHECKPOINT_VOLUME_MOUNT_PATH)/checkpoint_path
    save_path = model_path/"evals"  # Create evals subfolder path
    
    # Using IS_PEFT global variable as in our local implementation
    if IS_PEFT:
        adapter_config_path = model_path/"adapter_config.json"
        if not adapter_config_path.exists():
            raise FileNotFoundError(f"PEFT adapter config not found at {adapter_config_path}. Check IS_PEFT setting or model path.")
        print("PEFT adapter detected, converting format...")
        convert_peft_adapter_format(str(model_path))
    
    print("\nEvaluating model...")
    eval_cmd = [
        "composer",
        "eval/eval.py",
        "eval/yamls/hf_lora_eval.yaml",  # Note: Must rename from .yml to .yaml
        "icl_tasks=eval/yamls/copa.yaml",
        f"variables.model_name_or_path={model_path}",
        f"variables.lora_id_or_path={model_path if IS_PEFT else ''}",  # Add for PEFT models
        f"results_path={save_path}"
    ]
    result = subprocess.run(eval_cmd, capture_output=True, text=True)
    print(result.stdout)
    if result.stderr:
        print("Evaluation errors:", result.stderr)
    
    # Restore original safetensors files
    if IS_PEFT:
        print("Restoring original safetensors files...")
        restore_safetensors_after_eval(str(model_path))
    
    MODEL_CHECKPOINT_VOLUME.commit()  # Commit the new eval results
    print("Evaluation complete!")
```

## Important Notes

1. **File Extension**: Please manually rename `hf_lora_eval.yml` to `hf_lora_eval.yaml`.  All the other files in that folder have .yaml extension and configs expect this.  This was almost certainly a typo in llm-foundry.
2. **Global IS_PEFT**: The code assumes you're using the global IS_PEFT variable, as in our local implementation
3. **Path Conversion**: Note how we convert Path objects to strings when calling the utility functions
4. **Working Directory**: The utilities expect absolute paths to the model directory

These changes enable reliable evaluation of PEFT adapter models across different environments.