### PR TITLE
Basic custom llama smollm2

### DIFF
--- a/llmfoundry/models/llama/custom_model.py
+++ b/llmfoundry/models/llama/custom_model.py
@@ -1,0 +1,405 @@
+# coding=utf-8
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional
+import torch
+from torch import nn
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers import PreTrainedTokenizerBase
+from composer.models import ComposerModel
+from llmfoundry.metrics import DEFAULT_CAUSAL_LM_EVAL_METRICS, DEFAULT_CAUSAL_LM_TRAIN_METRICS
+from llmfoundry.utils.builders import build_metric
+
+from transformers import AutoModelForCausalLM
+
+SMOLLM2_CONFIG_135M = LlamaConfig(
+    attention_bias = False,
+    attention_dropout = 0.0,
+    bos_token_id = 0,
+    eos_token_id = 0,
+    head_dim = 64,
+    hidden_act = "silu",
+    hidden_size = 576,
+    initializer_range = 0.041666666666666664,
+    intermediate_size = 1536,
+    is_llama_config = True,
+    max_position_embeddings = 8192,
+    mlp_bias = False,
+    model_type = "llama",
+    num_attention_heads = 9,
+    num_hidden_layers = 30,
+    num_key_value_heads = 3,
+    pretraining_tp = 1,
+    rms_norm_eps = 1e-05,
+    rope_interleaved = False,
+    rope_scaling = None,
+    rope_theta = 100000,
+    tie_word_embeddings = True,
+    torch_dtype = "bfloat16",
+    transformers_version = "4.55.0.dev0",
+    use_cache = True,
+    vocab_size = 49152
+)
+
+class LlamaRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+class LlamaRotaryEmbedding(nn.Module):
+    def __init__(self, config: LlamaConfig, device: Optional[torch.device] = None):
+        super().__init__()
+        self.rope_type = "default"
+        self.config = config
+        head_dim = self.config.head_dim
+        inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0,head_dim,2)[:(head_dim//2)].float()/head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    @torch.no_grad()  # type: ignore
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float().to(x.device)
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+def apply_rotary_pos_emb(q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1) -> tuple[torch.Tensor, torch.Tensor]:
+    """Applies Rotary Position Embedding to the query and key tensors."""
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+class LlamaMLP(nn.Module):
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=config.mlp_bias)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=config.mlp_bias)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=config.mlp_bias)
+        self.act_fn = nn.SiLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+class LlamaAttention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+    def __init__(self, config: LlamaConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+        self.q_proj = nn.Linear(config.hidden_size, config.num_attention_heads*self.head_dim, bias=config.attention_bias)
+        self.k_proj = nn.Linear(config.hidden_size, config.num_key_value_heads*self.head_dim, bias=config.attention_bias)
+        self.v_proj = nn.Linear(config.hidden_size, config.num_key_value_heads*self.head_dim, bias=config.attention_bias)
+        self.o_proj = nn.Linear(config.num_attention_heads*self.head_dim, config.hidden_size, bias=config.attention_bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+        
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        attn_output = nn.functional.scaled_dot_product_attention(
+            query_states, key_states, value_states, is_causal=self.is_causal, 
+            scale=self.scaling, enable_gqa=True).transpose(1,2)
+
+        attn_output = attn_output.reshape(*input_shape, -1)
+        attn_output = self.o_proj(attn_output)
+        return attn_output
+
+class LlamaDecoderLayer(nn.Module):
+    def __init__(self, config: LlamaConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = LlamaAttention(config=config, layer_idx=layer_idx)
+        self.mlp = LlamaMLP(config)
+        self.input_layernorm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor]:
+        
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+def assign(left: torch.Tensor, right: torch.Tensor, tensor_name: str = "unknown") -> torch.nn.Parameter:
+    if left.shape != right.shape:
+        raise ValueError(f"Shape mismatch in tensor '{tensor_name}'. Left: {left.shape}, Right: {right.shape}")
+
+    if isinstance(right, torch.Tensor):
+        return torch.nn.Parameter(right.clone().detach())
+    else:
+        return torch.nn.Parameter(torch.tensor(right))
+
+def load_weights_into_smollm2(model: 'LlamaModel', param_config: LlamaConfig, params: dict[str, torch.Tensor]) -> None:
+    model.embed_tokens.weight = assign(model.embed_tokens.weight, params["model.embed_tokens.weight"], "model.embed_tokens.weight")
+    
+    for l in range(param_config.num_hidden_layers):
+        model.layers[l].self_attn.q_proj.weight = assign(
+            model.layers[l].self_attn.q_proj.weight,
+            params[f"model.layers.{l}.self_attn.q_proj.weight"],
+            f"model.layers[{l}].self_attn.q_proj.weight"
+        )
+        model.layers[l].self_attn.k_proj.weight = assign(
+            model.layers[l].self_attn.k_proj.weight,
+            params[f"model.layers.{l}.self_attn.k_proj.weight"],
+            f"model.layers.{l}.self_attn.k_proj.weight"
+        )
+        model.layers[l].self_attn.v_proj.weight = assign(
+            model.layers[l].self_attn.v_proj.weight,
+            params[f"model.layers.{l}.self_attn.v_proj.weight"],
+            f"model.layers.{l}.self_attn.v_proj.weight"
+        )
+        model.layers[l].self_attn.o_proj.weight = assign(
+            model.layers[l].self_attn.o_proj.weight,
+            params[f"model.layers.{l}.self_attn.o_proj.weight"],
+            f"model.layers.{l}.self_attn.o_proj.weight"
+        )
+        model.layers[l].input_layernorm.weight = assign(
+            model.layers[l].input_layernorm.weight,
+            params[f"model.layers.{l}.input_layernorm.weight"],
+            f"model.layers.{l}.input_layernorm.weight"
+        )
+
+        # Load FeedForward weights
+        model.layers[l].mlp.gate_proj.weight = assign(
+            model.layers[l].mlp.gate_proj.weight,
+            params[f"model.layers.{l}.mlp.gate_proj.weight"],
+            f"model.layers.{l}.mlp.gate_proj.weight"
+        )
+        model.layers[l].mlp.up_proj.weight = assign(
+            model.layers[l].mlp.up_proj.weight,
+            params[f"model.layers.{l}.mlp.up_proj.weight"],
+            f"model.layers.{l}.mlp.up_proj.weight"
+        )
+        model.layers[l].mlp.down_proj.weight = assign(
+            model.layers[l].mlp.down_proj.weight,
+            params[f"model.layers.{l}.mlp.down_proj.weight"],
+            f"model.layers.{l}.mlp.down_proj.weight"
+        )
+        model.layers[l].post_attention_layernorm.weight = assign(
+            model.layers[l].post_attention_layernorm.weight,
+            params[f"model.layers.{l}.post_attention_layernorm.weight"],
+            f"model.layers.{l}.post_attention_layernorm.weight"
+        )
+
+    model.norm.weight = assign(model.norm.weight, params["model.norm.weight"], "model.norm.weight")
+    model.lm_head.weight = assign(model.lm_head.weight, params["lm_head.weight"], "lm_head.weight")
+
+class LlamaModel(nn.Module):
+    def __init__(self, config: LlamaConfig):
+        super().__init__()
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([LlamaDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.rotary_emb = LlamaRotaryEmbedding(config=config)
+        if config.tie_word_embeddings:    # weight tying
+            self.embed_tokens.weight = self.lm_head.weight
+            
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs: Any,
+    ):
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+        if hidden_states is None:
+            raise ValueError("inputs_embeds cannot be None")
+        position_embeddings = self.rotary_emb(hidden_states, torch.arange(hidden_states.shape[1], device=hidden_states.device).unsqueeze(0))
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            hidden_states = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+        return self.lm_head(self.norm(hidden_states))
+
+    @classmethod
+    def from_pretrained(cls, model_type: str, device_map: str = "auto", torch_dtype: torch.dtype = torch.bfloat16):
+        if model_type == "smollm2-135m":
+            checkpoint = "HuggingFaceTB/SmolLM2-135M"
+            config = SMOLLM2_CONFIG_135M
+        elif model_type == "smollm2-7b":
+            checkpoint = "HuggingFaceTB/SmolLM2-7B"
+            raise NotImplementedError("SmolLM2-7B config not yet implemented")
+        else:
+            raise ValueError(f"Model type {model_type} not supported")
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        model_hf = AutoModelForCausalLM.from_pretrained(checkpoint, device_map=device_map, torch_dtype=torch_dtype).to(device)
+        sd_hf = model_hf.state_dict()
+        model = cls(config)
+        load_weights_into_smollm2(model, config, sd_hf)
+        return model
+
+class CustomLlamaModel(ComposerModel):
+    """Custom Llama model wrapper for LLM Foundry compatibility."""
+    
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        model_type: str = "smollm2-135m",
+        use_train_metrics: bool = True,
+        additional_train_metrics: Optional[list] = None,
+        additional_eval_metrics: Optional[list] = None,
+        **kwargs: Any,  # Accept additional kwargs to be compatible with LLM Foundry
+    ):
+        super().__init__()
+        if model_type == "smollm2-135m" and "model_type" in kwargs:
+            model_type = kwargs["model_type"]
+        
+        _ = {k: v for k, v in kwargs.items() 
+             if k not in ['pretrained', 'pretrained_model_name_or_path', 'name', 'model_type']}
+        
+        self.tokenizer = tokenizer
+        # self.model = LlamaModel.from_pretrained(model_type)
+        self.model = LlamaModel(SMOLLM2_CONFIG_135M)
+        
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = self.model.to(self.device)
+        
+        # Build metrics
+        additional_train_metrics = additional_train_metrics or []
+        additional_eval_metrics = additional_eval_metrics or []
+        
+        train_metric_names = DEFAULT_CAUSAL_LM_TRAIN_METRICS + additional_train_metrics
+        self.train_metrics = [
+            build_metric(metric, {}) for metric in train_metric_names
+        ] if use_train_metrics else []
+        
+        eval_metric_names = DEFAULT_CAUSAL_LM_EVAL_METRICS + additional_eval_metrics
+        self.eval_metrics = [
+            build_metric(metric, {}) for metric in eval_metric_names
+        ]
+    
+    def forward(self, batch: dict[str, Any]) -> torch.Tensor:
+        input_ids = batch['input_ids']
+        outputs = self.model(input_ids=input_ids)
+        return outputs
+    
+    def loss(self, outputs: torch.Tensor, batch: dict[str, Any]) -> torch.Tensor:
+        labels = batch['labels']
+        shift_logits = outputs[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+        loss_fct = nn.CrossEntropyLoss()
+        loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+        return loss
+    
+    def get_metrics(self, is_train: bool = False) -> dict[str, Any]:
+        metrics = self.train_metrics if is_train else self.eval_metrics
+        return {metric.__class__.__name__: metric for metric in metrics}
+    
+    def update_metrics(self, batch: dict[str, Any], outputs: torch.Tensor, is_train: bool = False) -> None:
+        metrics = self.train_metrics if is_train else self.eval_metrics
+        for metric in metrics:
+            metric.update(outputs, batch['labels'])
+    
+    def update_metric(self, batch: dict[str, Any], outputs: torch.Tensor, metric: Any) -> None:
+        """Update a single metric - required by ComposerModel."""
+        metric.update(outputs, batch['labels'])
+
+    def generate(
+        self,
+        idx: torch.Tensor,
+        max_new_tokens: int = 100,
+        context_size: int = 8192,
+        temperature: float = 0.0,
+        top_k: int = 0,
+        eos_id: Optional[int] = None
+    ) -> torch.Tensor:
+        self.model.eval()
+        for _ in range(max_new_tokens):
+            idx_cond = idx[:, -context_size:]
+            logits = self.model(idx_cond)[:, -1, :]
+            if top_k > 0:
+                top_logits, _ = torch.topk(logits, top_k)
+                logits = torch.where(logits < top_logits[:, -1], torch.tensor(float('-inf')).to(logits.device), logits)
+            if temperature > 0.0:
+                idx_next = torch.multinomial(torch.softmax(logits / temperature, dim=-1), num_samples=1)
+            else:
+                idx_next = torch.argmax(logits, dim=-1, keepdim=True)
+            if eos_id is not None and idx_next == eos_id:
+                break
+            idx = torch.cat((idx, idx_next), dim=1) 
+        return idx

--- a/llmfoundry/models/llama/custom_model.py
+++ b/llmfoundry/models/llama/custom_model.py
@@ -58,7 +58,7 @@ SMOLLM2_CONFIG_135M = LlamaConfig(
     torch_dtype = "bfloat16",
     transformers_version = "4.55.0.dev0",
     use_cache = True,
-    vocab_size = 49152
+    vocab_size = 49152,
 )
 
 class LlamaRMSNorm(nn.Module):
@@ -215,49 +215,49 @@ def load_weights_into_smollm2(model: 'LlamaModel', param_config: LlamaConfig, pa
         model.layers[l].self_attn.q_proj.weight = assign(
             model.layers[l].self_attn.q_proj.weight,
             params[f"model.layers.{l}.self_attn.q_proj.weight"],
-            f"model.layers[{l}].self_attn.q_proj.weight"
+            f"model.layers[{l}].self_attn.q_proj.weight",
         )
         model.layers[l].self_attn.k_proj.weight = assign(
             model.layers[l].self_attn.k_proj.weight,
             params[f"model.layers.{l}.self_attn.k_proj.weight"],
-            f"model.layers.{l}.self_attn.k_proj.weight"
+            f"model.layers.{l}.self_attn.k_proj.weight",
         )
         model.layers[l].self_attn.v_proj.weight = assign(
             model.layers[l].self_attn.v_proj.weight,
             params[f"model.layers.{l}.self_attn.v_proj.weight"],
-            f"model.layers.{l}.self_attn.v_proj.weight"
+            f"model.layers.{l}.self_attn.v_proj.weight",
         )
         model.layers[l].self_attn.o_proj.weight = assign(
             model.layers[l].self_attn.o_proj.weight,
             params[f"model.layers.{l}.self_attn.o_proj.weight"],
-            f"model.layers.{l}.self_attn.o_proj.weight"
+            f"model.layers.{l}.self_attn.o_proj.weight",
         )
         model.layers[l].input_layernorm.weight = assign(
             model.layers[l].input_layernorm.weight,
             params[f"model.layers.{l}.input_layernorm.weight"],
-            f"model.layers.{l}.input_layernorm.weight"
+            f"model.layers.{l}.input_layernorm.weight",
         )
 
         # Load FeedForward weights
         model.layers[l].mlp.gate_proj.weight = assign(
             model.layers[l].mlp.gate_proj.weight,
             params[f"model.layers.{l}.mlp.gate_proj.weight"],
-            f"model.layers.{l}.mlp.gate_proj.weight"
+            f"model.layers.{l}.mlp.gate_proj.weight",
         )
         model.layers[l].mlp.up_proj.weight = assign(
             model.layers[l].mlp.up_proj.weight,
             params[f"model.layers.{l}.mlp.up_proj.weight"],
-            f"model.layers.{l}.mlp.up_proj.weight"
+            f"model.layers.{l}.mlp.up_proj.weight",
         )
         model.layers[l].mlp.down_proj.weight = assign(
             model.layers[l].mlp.down_proj.weight,
             params[f"model.layers.{l}.mlp.down_proj.weight"],
-            f"model.layers.{l}.mlp.down_proj.weight"
+            f"model.layers.{l}.mlp.down_proj.weight",
         )
         model.layers[l].post_attention_layernorm.weight = assign(
             model.layers[l].post_attention_layernorm.weight,
             params[f"model.layers.{l}.post_attention_layernorm.weight"],
-            f"model.layers.{l}.post_attention_layernorm.weight"
+            f"model.layers.{l}.post_attention_layernorm.weight",
         )
 
     model.norm.weight = assign(model.norm.weight, params["model.norm.weight"], "model.norm.weight")
@@ -324,9 +324,7 @@ class LlamaModel(nn.Module):
         inputs_embeds: Optional[torch.FloatTensor] = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """
-        Prepare inputs for generation. Required by PEFT and HuggingFace generation utilities.
-        """
+        """Prepare inputs for generation. Required by PEFT and HuggingFace generation utilities."""
         if past_key_values is not None:
             input_ids = input_ids[:, -1:]
 
@@ -374,6 +372,16 @@ class CustomLlamaModel(BaseHuggingFaceModel):
         )    
     
     def forward(self, batch: dict[str, Any]) -> torch.Tensor:
+        # input_ids = batch['input_ids']
+        
+        # # Create attention mask if not provided (mark non-padding tokens as 1)
+        # attention_mask = batch.get('attention_mask')
+        # if attention_mask is None:
+        #     # Assume padding token is 0 (EOS token based on your config)
+        #     attention_mask = (input_ids != 0).long()
+        # print('attention_mask:', attention_mask)
+        # print('sum of attention_mask:', attention_mask.sum(dim=1))
+        # return self.model(input_ids=input_ids, attention_mask=attention_mask)
         return self.model(input_ids=batch['input_ids'])
 
     def loss(self, outputs: torch.Tensor, batch: dict[str, Any]) -> torch.Tensor:
@@ -382,7 +390,7 @@ class CustomLlamaModel(BaseHuggingFaceModel):
         return F.cross_entropy(
             outputs.flatten(0, -2),
             targets.flatten(),
-            ignore_index=CROSS_ENTROPY_IGNORE_INDEX
+            ignore_index=CROSS_ENTROPY_IGNORE_INDEX,
         )
 
     def generate(
@@ -392,7 +400,7 @@ class CustomLlamaModel(BaseHuggingFaceModel):
         context_size: int = 8192,
         temperature: float = 0.0,
         top_k: int = 0,
-        eos_id: Optional[int] = None
+        eos_id: Optional[int] = None,
     ) -> torch.Tensor:
         model = self.model.eval()
         for _ in range(max_new_tokens):

--- a/llmfoundry/models/llama/custom_model.py
+++ b/llmfoundry/models/llama/custom_model.py
@@ -284,8 +284,6 @@ class LlamaModel(nn.Module):
             inputs_embeds = self.embed_tokens(input_ids)
 
         hidden_states = inputs_embeds
-        if hidden_states is None:
-            raise ValueError("inputs_embeds cannot be None")
         position_embeddings = self.rotary_emb(hidden_states, torch.arange(hidden_states.shape[1], device=hidden_states.device).unsqueeze(0))
 
         for decoder_layer in self.layers[: self.config.num_hidden_layers]:
@@ -301,9 +299,9 @@ class LlamaModel(nn.Module):
         if model_type == "smollm2-135m":
             checkpoint = "HuggingFaceTB/SmolLM2-135M"
             config = SMOLLM2_CONFIG_135M
-        elif model_type == "smollm2-7b":
-            checkpoint = "HuggingFaceTB/SmolLM2-7B"
-            raise NotImplementedError("SmolLM2-7B config not yet implemented")
+        elif model_type == "smollm2-1.7b":
+            checkpoint = "HuggingFaceTB/SmolLM2-1.7B"
+            raise NotImplementedError("SmolLM2-1.7B config not yet implemented")
         else:
             raise ValueError(f"Model type {model_type} not supported")
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -333,8 +331,7 @@ class CustomLlamaModel(ComposerModel):
              if k not in ['pretrained', 'pretrained_model_name_or_path', 'name', 'model_type']}
         
         self.tokenizer = tokenizer
-        # self.model = LlamaModel.from_pretrained(model_type)
-        self.model = LlamaModel(SMOLLM2_CONFIG_135M)
+        self.model = LlamaModel.from_pretrained(model_type)
         
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = self.model.to(self.device)

--- a/llmfoundry/models/llama/register.py
+++ b/llmfoundry/models/llama/register.py
@@ -9,6 +9,5 @@ def get_custom_llama_model():
 def register_custom_llama_model():
     """Register the custom Llama model with the registry."""
     from llmfoundry import registry
-    # registry.models.register("hf_causal_lm")(CustomLlamaModel)
     registry.models.register("smollm2-135m")(CustomLlamaModel)
     return CustomLlamaModel 

--- a/llmfoundry/models/llama/register.py
+++ b/llmfoundry/models/llama/register.py
@@ -1,0 +1,14 @@
+"""Registration utilities for Llama models."""
+
+from llmfoundry.models.llama.custom_model import CustomLlamaModel
+
+def get_custom_llama_model():
+    """Get the CustomLlamaModel class."""
+    return CustomLlamaModel
+
+def register_custom_llama_model():
+    """Register the custom Llama model with the registry."""
+    from llmfoundry import registry
+    # registry.models.register("hf_causal_lm")(CustomLlamaModel)
+    registry.models.register("smollm2-135m")(CustomLlamaModel)
+    return CustomLlamaModel 

--- a/llmfoundry/models/llama/register.py
+++ b/llmfoundry/models/llama/register.py
@@ -9,5 +9,5 @@ def get_custom_llama_model():
 def register_custom_llama_model():
     """Register the custom Llama model with the registry."""
     from llmfoundry import registry
-    registry.models.register("smollm2-135m")(CustomLlamaModel)
-    return CustomLlamaModel 
+    registry.models.register("custom-smollm2-135m")(CustomLlamaModel)
+    return CustomLlamaModel

--- a/llmfoundry/utils/builders.py
+++ b/llmfoundry/utils/builders.py
@@ -530,6 +530,11 @@ def build_tokenizer(
             f'The tokenizer {tokenizer_name} must have an eos_token.',
         )
 
+    # Ensure a pad token exists for padding collators (e.g., DataCollatorForLanguageModeling)
+    # Many decoder-only tokenizers (GPT-2 style) do not define a pad token by default.
+    if getattr(tokenizer, 'pad_token_id', None) is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
     if dist.is_available() and dist.is_initialized(
     ) and dist.get_world_size() > 1:
         if dist.get_local_rank() == 0:

--- a/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
+++ b/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
@@ -13,6 +13,7 @@ run_name: ${variables.run_name}
 model:
   name: smollm2-135m
   model_type: smollm2-135m
+  pretrained: true
 
 # Tokenizer
 tokenizer:
@@ -76,7 +77,7 @@ algorithms:
     clipping_threshold: 1.0
 
 # Training duration and evaluation
-max_duration: 50ba 
+max_duration: 5ba 
 eval_interval: 100ba
 eval_first: false
 eval_subset_num_batches: 10  # Only evaluate on 10 batches
@@ -109,4 +110,12 @@ callbacks:
     window_size: 10
   lr_monitor: {}
   memory_monitor: {}
-  runtime_estimator: {} 
+  runtime_estimator: {}
+  text_generation:
+    prompts:
+      - "The future of artificial intelligence is"
+      - "In a world where technology"
+      - "The most important thing to remember is"
+      - "When I think about machine learning"
+    max_new_tokens: 50
+    temperature: 0.7 

--- a/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
+++ b/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
@@ -30,10 +30,9 @@ loggers:
 train_loader:
   name: text
   dataset:
-    streams:
-      local: ${variables.data_local}
-      remote: ${variables.data_remote}
-      split: train_small
+    local: ${variables.data_local}
+    remote: ${variables.data_remote}
+    split: train_small
     shuffle: true
     max_seq_len: ${variables.max_seq_len}
     shuffle_seed: ${variables.global_seed}
@@ -45,10 +44,9 @@ train_loader:
 eval_loader:
   name: text
   dataset:
-    streams:
-      local: ${variables.data_local}
-      remote: ${variables.data_remote}
-      split: val_small
+    local: ${variables.data_local}
+    remote: ${variables.data_remote}
+    split: val_small
     shuffle: false
     max_seq_len: ${variables.max_seq_len}
     shuffle_seed: ${variables.global_seed}
@@ -78,10 +76,12 @@ algorithms:
     clipping_threshold: 1.0
 
 # Training duration and evaluation
-max_duration: 10ba  # Reduced for quick testing
+max_duration: 50ba 
 eval_interval: 100ba
 eval_first: false
-eval_subset_num_batches: -1
+eval_subset_num_batches: 10  # Only evaluate on 10 batches
+save_overwrite: true
+save_interval: 0ba  # Disable checkpointing
 
 # System configuration
 seed: ${variables.global_seed}

--- a/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
+++ b/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
@@ -19,35 +19,41 @@ tokenizer:
   name: ${variables.tokenizer_name}
   kwargs:
     model_max_length: ${variables.max_seq_len}
-
+  
 loggers:
-  aim:
-    repo: '.aim'
-    experiment_name: 'custom_smollm2_135m_training'
-    upload_on_close: true
+  wandb:
+    project: 'smollm2-135m-training'
+    entity: 'local-research-group'
+    name: 'smollm2-135m-training'
 
 # Data loaders
 train_loader:
   name: text
   dataset:
-    local: ${variables.data_local}
-    remote: ${variables.data_remote}
-    split: train_small
+    streams:
+      local: ${variables.data_local}
+      remote: ${variables.data_remote}
+      split: train_small
     shuffle: true
     max_seq_len: ${variables.max_seq_len}
     shuffle_seed: ${variables.global_seed}
+    deorder_only_format: true
+    eos_token_id: 0
   drop_last: true
   num_workers: 4
 
 eval_loader:
   name: text
   dataset:
-    local: ${variables.data_local}
-    remote: ${variables.data_remote}
-    split: val_small
+    streams:
+      local: ${variables.data_local}
+      remote: ${variables.data_remote}
+      split: val_small
     shuffle: false
     max_seq_len: ${variables.max_seq_len}
     shuffle_seed: ${variables.global_seed}
+    deorder_only_format: true
+    eos_token_id: 0
   drop_last: false
   num_workers: 4
 
@@ -76,12 +82,12 @@ max_duration: 10ba  # Reduced for quick testing
 eval_interval: 100ba
 eval_first: false
 eval_subset_num_batches: -1
-global_train_batch_size: 16  # Reduced for GPU memory constraints
 
 # System configuration
 seed: ${variables.global_seed}
 device_eval_batch_size: 2
 device_train_microbatch_size: 2
+global_train_batch_size: 4
 precision: amp_bf16
 
 # FSDP configuration

--- a/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
+++ b/scripts/train/yamls/pretrain/custom_smollm2-135m.yaml
@@ -1,0 +1,106 @@
+variables:
+  data_local: datasets/c4_small
+  data_remote: # If blank, files must be present in data_local
+  tokenizer_name: HuggingFaceTB/SmolLM2-135M
+  global_seed: 42
+  max_seq_len: 2048
+  run_name: custom_smollm2_135m_training
+
+max_seq_len: ${variables.max_seq_len}
+run_name: ${variables.run_name}
+
+# Model - Using custom SmolLM2-135M model
+model:
+  name: smollm2-135m
+  model_type: smollm2-135m
+
+# Tokenizer
+tokenizer:
+  name: ${variables.tokenizer_name}
+  kwargs:
+    model_max_length: ${variables.max_seq_len}
+
+loggers:
+  aim:
+    repo: '.aim'
+    experiment_name: 'custom_smollm2_135m_training'
+    upload_on_close: true
+
+# Data loaders
+train_loader:
+  name: text
+  dataset:
+    local: ${variables.data_local}
+    remote: ${variables.data_remote}
+    split: train_small
+    shuffle: true
+    max_seq_len: ${variables.max_seq_len}
+    shuffle_seed: ${variables.global_seed}
+  drop_last: true
+  num_workers: 4
+
+eval_loader:
+  name: text
+  dataset:
+    local: ${variables.data_local}
+    remote: ${variables.data_remote}
+    split: val_small
+    shuffle: false
+    max_seq_len: ${variables.max_seq_len}
+    shuffle_seed: ${variables.global_seed}
+  drop_last: false
+  num_workers: 4
+
+# Training configuration
+scheduler:
+  name: cosine_with_warmup
+  t_warmup: 100ba
+  alpha_f: 0.1
+
+optimizer:
+  name: decoupled_adamw
+  lr: 6.0e-4
+  betas:
+  - 0.9
+  - 0.95
+  eps: 1.0e-08
+  weight_decay: 0.0
+
+algorithms:
+  gradient_clipping:
+    clipping_type: norm
+    clipping_threshold: 1.0
+
+# Training duration and evaluation
+max_duration: 10ba  # Reduced for quick testing
+eval_interval: 100ba
+eval_first: false
+eval_subset_num_batches: -1
+global_train_batch_size: 16  # Reduced for GPU memory constraints
+
+# System configuration
+seed: ${variables.global_seed}
+device_eval_batch_size: 2
+device_train_microbatch_size: 2
+precision: amp_bf16
+
+# FSDP configuration
+fsdp_config:
+  sharding_strategy: FULL_SHARD
+  mixed_precision: PURE
+  activation_checkpointing: false
+  activation_checkpointing_reentrant: false
+  activation_cpu_offload: false
+  limit_all_gathers: true
+
+# Logging
+progress_bar: true
+log_to_console: true
+console_log_interval: 1ba
+
+callbacks:
+  speed_monitor:
+    window_size: 10
+  lr_monitor: {}
+  memory_monitor: {}
+  runtime_estimator: {} 

--- a/scripts/train/yamls/pretrain/custom_smollm2-135m_peft.yaml
+++ b/scripts/train/yamls/pretrain/custom_smollm2-135m_peft.yaml
@@ -4,19 +4,33 @@ variables:
   tokenizer_name: HuggingFaceTB/SmolLM2-135M
   global_seed: 42
   max_seq_len: 2048
-  run_name: custom_smollm2_135m_training
+  run_name: custom_smollm2_135m_peft_training
 
 max_seq_len: ${variables.max_seq_len}
 run_name: ${variables.run_name}
 
-# Model - Using custom SmolLM2-135M model
 model:
   name: custom-smollm2-135m
-  model_type: smollm2-135m
-  pretrained: false
   pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M
+  model_type: smollm2-135m
+  pretrained: true
+  peft_config:
+    peft_type: LORA
+    task_type: CAUSAL_LM
+    r: 64
+    lora_alpha: 128
+    lora_dropout: 0.05
+    target_modules:
+      - q_proj
+      - k_proj
+      - v_proj
+      - o_proj
+      - gate_proj
+      - up_proj
+      - down_proj
+    use_rslora: false
+    use_dora: false
 
-# Tokenizer
 tokenizer:
   name: ${variables.tokenizer_name}
   kwargs:
@@ -24,11 +38,10 @@ tokenizer:
   
 loggers:
   wandb:
-    project: 'smollm2-135m-training-avelina'
+    project: 'smollm2-135m-peft-training-avelina'
     entity: 'local-research-group'
-    name: 'smollm2-135m-training-avelina-1k'
+    name: 'smollm2-135m-peft-training-avelina-1k'
 
-# Data loaders
 train_loader:
   name: text
   dataset:
@@ -57,7 +70,6 @@ eval_loader:
   drop_last: false
   num_workers: 4
 
-# Training configuration
 scheduler:
   name: cosine_with_warmup
   t_warmup: 100ba
@@ -77,22 +89,19 @@ algorithms:
     clipping_type: norm
     clipping_threshold: 1.0
 
-# Training duration and evaluation
-max_duration: 1000ba
-eval_interval: 100ba
+max_duration: 100ba
+eval_interval: 200ba
 eval_first: false
-eval_subset_num_batches: 5
+eval_subset_num_batches: 50
 save_overwrite: true
-save_interval: 0ba  # Disable checkpointing
+save_interval: 200ba  # Save PEFT checkpoints
 
-# System configuration
 seed: ${variables.global_seed}
 device_eval_batch_size: 2
-device_train_microbatch_size: 4
+device_train_microbatch_size: 2
 global_train_batch_size: 4
 precision: amp_bf16
 
-# FSDP configuration
 fsdp_config:
   sharding_strategy: FULL_SHARD
   mixed_precision: PURE
@@ -101,7 +110,6 @@ fsdp_config:
   activation_cpu_offload: false
   limit_all_gathers: true
 
-# Logging
 progress_bar: true
 log_to_console: true
 console_log_interval: 1ba
@@ -116,7 +124,7 @@ callbacks:
     prompts:
       - "The future of artificial intelligence is"
       - "In a world where technology"
-      - "def main():"
+      - "The most important thing to remember is"
       - "Gravity is"
     max_new_tokens: 50
     temperature: 0.

--- a/simple_train_smollm2.py
+++ b/simple_train_smollm2.py
@@ -16,6 +16,9 @@ from llmfoundry.models.llama.register import register_custom_llama_model
 from llmfoundry.command_utils.train import train
 from omegaconf import OmegaConf
 
+# Import the text generation callback to register it
+import text_generation_callback  # type: ignore
+
 # Set up logging
 logging.basicConfig(
     level=logging.INFO,

--- a/simple_train_smollm2.py
+++ b/simple_train_smollm2.py
@@ -47,6 +47,10 @@ def main():
     logger.info(f"Model checkpoints will be saved to: {save_folder}")
     
     # Verify dataset path
+    # Install with:
+    # python scripts/data_prep/convert_dataset_hf.py --dataset allenai/c4 --data_subset en --out_root datasets/c4_small \
+    # --splits train_small val_small --concat_tokens 2048 --tokenizer HuggingFaceTB/SmolLM2-135M \
+    # --eos_text '<|endoftext|>' --compression zstd
     dataset_path = config.variables.data_local
     if not os.path.exists(dataset_path):
         logger.warning(f"Dataset not found at: {dataset_path}")

--- a/simple_train_smollm2.py
+++ b/simple_train_smollm2.py
@@ -21,7 +21,7 @@ import batch_inspection_callback  # type: ignore
 # Set up logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(levelname)s - %(message)s',
 )
 logger = logging.getLogger(__name__)
 

--- a/simple_train_smollm2.py
+++ b/simple_train_smollm2.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Simplified training script for custom SmolLM2-135M model.
+"""
+
+import os
+import sys
+import logging
+from pathlib import Path
+
+# Add the project root to the path
+project_root = Path(__file__).parent
+sys.path.insert(0, str(project_root))
+
+from llmfoundry.models.llama.register import register_custom_llama_model
+from llmfoundry.command_utils.train import train
+from omegaconf import OmegaConf
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def main():
+    """Main training function."""
+    
+    # Register the custom model
+    logger.info("Registering custom SmolLM2-135M model...")
+    register_custom_llama_model()
+    logger.info("Custom model registered successfully!")
+    
+    # Load the training configuration
+    config_path = "scripts/train/yamls/pretrain/custom_smollm2-135m.yaml"
+    logger.info(f"Loading configuration from: {config_path}")
+    
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+    
+    config = OmegaConf.load(config_path)
+    
+    # Set save folder
+    save_folder = "model-checkpoints/custom_smollm2_135m"
+    config.save_folder = save_folder
+    os.makedirs(save_folder, exist_ok=True)
+    logger.info(f"Model checkpoints will be saved to: {save_folder}")
+    
+    # Verify dataset path
+    dataset_path = config.variables.data_local
+    if not os.path.exists(dataset_path):
+        logger.warning(f"Dataset not found at: {dataset_path}")
+        logger.info("Please ensure the C4 dataset is available in the datasets/c4_small directory")
+        logger.info("You can download it or create a symbolic link to the correct location")
+        return
+    
+    logger.info(f"Using dataset at: {dataset_path}")
+    
+    # Start training
+    logger.info("Starting training...")
+    try:
+        trainer = train(config)
+        logger.info("Training completed successfully!")
+        return trainer
+    except Exception as e:
+        logger.error(f"Training failed: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
+        raise
+
+if __name__ == "__main__":
+    main() 

--- a/simple_train_smollm2.py
+++ b/simple_train_smollm2.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Simplified training script for custom SmolLM2-135M model.
-"""
+"""Simplified training script for custom SmolLM2-135M model."""
 
 import os
 import sys
@@ -16,8 +14,9 @@ from llmfoundry.models.llama.register import register_custom_llama_model
 from llmfoundry.command_utils.train import train
 from omegaconf import OmegaConf
 
-# Import the text generation callback to register it
+# Import callbacks to register them
 import text_generation_callback  # type: ignore
+import batch_inspection_callback  # type: ignore
 
 # Set up logging
 logging.basicConfig(
@@ -28,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Main training function."""
-    
     # Register the custom model
     logger.info("Registering custom SmolLM2-135M model...")
     register_custom_llama_model()

--- a/simple_train_smollm2_peft.py
+++ b/simple_train_smollm2_peft.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Simplified training script for custom SmolLM2-135M model.
+Simplified PEFT training script for custom SmolLM2-135M model.
 """
 
 import os
@@ -8,7 +8,6 @@ import sys
 import logging
 from pathlib import Path
 
-# Add the project root to the path
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
@@ -16,10 +15,8 @@ from llmfoundry.models.llama.register import register_custom_llama_model
 from llmfoundry.command_utils.train import train
 from omegaconf import OmegaConf
 
-# Import the text generation callback to register it
 import text_generation_callback  # type: ignore
 
-# Set up logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s'
@@ -27,15 +24,12 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 def main():
-    """Main training function."""
-    
-    # Register the custom model
+    """Main PEFT training function."""
     logger.info("Registering custom SmolLM2-135M model...")
     register_custom_llama_model()
     logger.info("Custom model registered successfully!")
     
-    # Load the training configuration
-    config_path = "scripts/train/yamls/pretrain/custom_smollm2-135m.yaml"
+    config_path = "scripts/train/yamls/pretrain/custom_smollm2-135m_peft.yaml"
     logger.info(f"Loading configuration from: {config_path}")
     
     if not os.path.exists(config_path):
@@ -43,16 +37,13 @@ def main():
     
     config = OmegaConf.load(config_path)
     
-    # Set save folder
-    save_folder = "model-checkpoints/custom_smollm2_135m"
+    save_folder = "model-checkpoints/custom_smollm2_135m_peft"
     config.save_folder = save_folder
     os.makedirs(save_folder, exist_ok=True)
-    logger.info(f"Model checkpoints will be saved to: {save_folder}")
+    logger.info(f"PEFT model checkpoints will be saved to: {save_folder}")
     
-    # Verify dataset paths (support remote streaming)
     dataset_local = config.variables.data_local
     dataset_remote = getattr(config.variables, 'data_remote', None)
-
     if dataset_remote and str(dataset_remote).strip():
         os.makedirs(dataset_local, exist_ok=True)
         logger.info(
@@ -60,22 +51,34 @@ def main():
     else:
         if not os.path.exists(dataset_local):
             logger.warning(f"Dataset not found at: {dataset_local}")
-            logger.info("Set variables.data_remote to a remote MDS path (e.g., s3://... or https://...) to stream, "
-                        "or ensure the dataset exists locally.")
             return
         logger.info(f"Using local dataset at: {dataset_local}")
     
-    # Start training
-    logger.info("Starting training...")
+    if hasattr(config.model, 'peft_config') and config.model.peft_config:
+        peft_config = config.model.peft_config
+        logger.info("PEFT Configuration:")
+        logger.info(f"  - Type: {peft_config.peft_type}")
+        logger.info(f"  - Rank (r): {peft_config.r}")
+        logger.info(f"  - Alpha: {peft_config.lora_alpha}")
+        logger.info(f"  - Dropout: {peft_config.lora_dropout}")
+        logger.info(f"  - Target modules: {peft_config.target_modules}")
+        logger.info(f"  - Use RSLora: {peft_config.get('use_rslora', False)}")
+        logger.info(f"  - Use DoRA: {peft_config.get('use_dora', False)}")
+    else:
+        logger.warning("No PEFT configuration found!")
+        return
+    
+    logger.info("Starting PEFT training...")
     try:
         trainer = train(config)
-        logger.info("Training completed successfully!")
+        logger.info("PEFT training completed successfully!")
+        logger.info(f"PEFT adapters saved to: {save_folder}")
         return trainer
     except Exception as e:
-        logger.error(f"Training failed: {e}")
+        logger.error(f"PEFT training failed: {e}")
         import traceback
         logger.error(traceback.format_exc())
         raise
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/simple_train_smollm2_peft.py
+++ b/simple_train_smollm2_peft.py
@@ -17,7 +17,7 @@ import text_generation_callback  # type: ignore
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(levelname)s - %(message)s',
 )
 logger = logging.getLogger(__name__)
 

--- a/simple_train_smollm2_peft.py
+++ b/simple_train_smollm2_peft.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Simplified PEFT training script for custom SmolLM2-135M model.
-"""
+"""Simplified PEFT training script for custom SmolLM2-135M model."""
 
 import os
 import sys

--- a/text_generation_callback.py
+++ b/text_generation_callback.py
@@ -31,9 +31,6 @@ class TextGenerationCallback(Callback):
         """
         self.prompts = prompts or [
             "The future of artificial intelligence is",
-            "In a world where technology",
-            "The most important thing to remember is",
-            "When I think about machine learning"
         ]
         self.max_new_tokens = max_new_tokens
         self.temperature = temperature

--- a/text_generation_callback.py
+++ b/text_generation_callback.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Callback for text generation during training.
-"""
+"""Callback for text generation during training."""
 
 import logging
 from typing import Optional
@@ -18,10 +16,9 @@ class TextGenerationCallback(Callback):
         prompts: Optional[list[str]] = None,
         max_new_tokens: int = 50,
         temperature: float = 0.7,
-        log_to_wandb: bool = True
+        log_to_wandb: bool = True,
     ):
-        """
-        Initialize the callback.
+        """Initialize the callback.
         
         Args:
             prompts: List of prompts to generate text from
@@ -57,7 +54,7 @@ class TextGenerationCallback(Callback):
                         idx=input_ids,
                         max_new_tokens=self.max_new_tokens,
                         temperature=self.temperature,
-                        eos_id=model.tokenizer.eos_token_id
+                        eos_id=model.tokenizer.eos_token_id,
                     )
                     generated_text = model.tokenizer.decode(generated_ids[0], skip_special_tokens=True)
                     print(f"\nPrompt {i+1}: {prompt}")
@@ -65,13 +62,13 @@ class TextGenerationCallback(Callback):
                     print("-" * 40)                    
                     generated_texts[f"prompt_{i+1}"] = {
                         "prompt": prompt,
-                        "generated": generated_text
+                        "generated": generated_text,
                     }
-                except Exception as e:
+                except Exception as e:  # noqa: PERF203
                     print(f"Error generating text for prompt {i+1}: {e}")
                     generated_texts[f"prompt_{i+1}"] = {
                         "prompt": prompt,
-                        "error": str(e)
+                        "error": str(e),
                     }
             
             if self.log_to_wandb and hasattr(logger, 'log_metrics'):
@@ -79,7 +76,7 @@ class TextGenerationCallback(Callback):
                     if "error" not in value:
                         logger.log_metrics({
                             f"generation/{event_name}/{key}/prompt": str(value["prompt"]),
-                            f"generation/{event_name}/{key}/text": str(value["generated"])
+                            f"generation/{event_name}/{key}/text": str(value["generated"]),
                         })
                         print(f"WandB Logged: {event_name} - {key}")
                         print(f"  Prompt: {value['prompt']}")

--- a/text_generation_callback.py
+++ b/text_generation_callback.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Callback for text generation during training.
+"""
+
+import logging
+from typing import Optional
+from composer.core import Callback, State
+from composer.loggers import Logger
+
+logger = logging.getLogger(__name__)
+
+class TextGenerationCallback(Callback):
+    """Callback that generates text at specific training events."""
+    
+    def __init__(
+        self,
+        prompts: Optional[list[str]] = None,
+        max_new_tokens: int = 50,
+        temperature: float = 0.7,
+        log_to_wandb: bool = True
+    ):
+        """
+        Initialize the callback.
+        
+        Args:
+            prompts: List of prompts to generate text from
+            max_new_tokens: Maximum number of tokens to generate
+            temperature: Sampling temperature
+            log_to_wandb: Whether to log to wandb
+        """
+        self.prompts = prompts or [
+            "The future of artificial intelligence is",
+            "In a world where technology",
+            "The most important thing to remember is",
+            "When I think about machine learning"
+        ]
+        self.max_new_tokens = max_new_tokens
+        self.temperature = temperature
+        self.log_to_wandb = log_to_wandb
+        
+    def _generate_and_log_text(self, state: State, logger: Logger, event_name: str):
+        """Generate text and log it."""
+        try:
+            model = state.model
+            if not hasattr(model, 'generate'):
+                logger.warning("Model does not have generate method")
+                return
+                
+            print(f"\n{'='*60}")
+            print(f"TEXT GENERATION - {event_name}")
+            print(f"{'='*60}")
+            
+            generated_texts = {}
+            
+            for i, prompt in enumerate(self.prompts):
+                try:
+                    input_ids = model.tokenizer.encode(prompt, return_tensors='pt').to(model.device)
+                    generated_ids = model.generate(
+                        idx=input_ids,
+                        max_new_tokens=self.max_new_tokens,
+                        temperature=self.temperature,
+                        eos_id=model.tokenizer.eos_token_id
+                    )
+                    generated_text = model.tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+                    print(f"\nPrompt {i+1}: {prompt}")
+                    print(f"Generated: {generated_text}")
+                    print("-" * 40)                    
+                    generated_texts[f"prompt_{i+1}"] = {
+                        "prompt": prompt,
+                        "generated": generated_text
+                    }
+                except Exception as e:
+                    print(f"Error generating text for prompt {i+1}: {e}")
+                    generated_texts[f"prompt_{i+1}"] = {
+                        "prompt": prompt,
+                        "error": str(e)
+                    }
+            
+            if self.log_to_wandb and hasattr(logger, 'log_metrics'):
+                for key, value in generated_texts.items():
+                    if "error" not in value:
+                        logger.log_metrics({
+                            f"generation/{event_name}/{key}/prompt": str(value["prompt"]),
+                            f"generation/{event_name}/{key}/text": str(value["generated"])
+                        })
+                        print(f"WandB Logged: {event_name} - {key}")
+                        print(f"  Prompt: {value['prompt']}")
+                        print(f"  Generated: {value['generated']}")
+                        print()
+            
+        except Exception as e:
+            print(f"Error in text generation callback: {e}")
+    
+    def fit_start(self, state: State, logger: Logger) -> None:
+        """Generate text before training starts."""
+        self._generate_and_log_text(state, logger, "BEFORE_TRAINING")
+    
+    def eval_start(self, state: State, logger: Logger) -> None:
+        """Generate text before evaluation starts."""
+        self._generate_and_log_text(state, logger, "BEFORE_EVAL")
+    
+from llmfoundry.registry import callbacks
+callbacks.register('text_generation', func=TextGenerationCallback) 


### PR DESCRIPTION
This PR adds a custom llama model for smollm2-135m model. The model loads weights from hugging face and trains with llm foundry. By using `simple_train_smollm2.py` it trains on c4 dataset using the `scripts/train/yamls/pretrain/custom_smollm2-135m.yaml`.  It also uses a callback to generate text sample before each eval.

I created the model mostly from Hugging Face llama code as it gave me more numerical stability than Rashcka's implementation. So, I added Hugging Face and EleutherAI's license in my llama code.

It currently uses sdpa, but I plan on switching to flash attention varlen when I add ModernBert unpadding. 
It still needs PEFT, KV cache, and modal support. 